### PR TITLE
Fix list alignment

### DIFF
--- a/horsey.styl
+++ b/horsey.styl
@@ -1,6 +1,7 @@
 .sey-list
   display none
   position absolute
+  padding 0
   list-style-type none
   box-shadow 1px 2px 6px
   background-color #fff


### PR DESCRIPTION
Hi @bevacqua,

Thanks for your open source work (horsey and insignia, in particular)!

This PR removes the padding from `.sey-list`, fixing the alignment with the field

**Before:**
![screen shot 2015-03-13 at 15 42 53](https://cloud.githubusercontent.com/assets/111734/6641936/ef028144-c998-11e4-879f-16c0bef06b1e.png)

**After:**
![screen shot 2015-03-13 at 15 54 28](https://cloud.githubusercontent.com/assets/111734/6641988/52fc7d1c-c999-11e4-8f3a-e6acf6b879d2.png)