### PR TITLE
Chinese search bug fixed

### DIFF
--- a/dist/horsey.js
+++ b/dist/horsey.js
@@ -344,6 +344,9 @@ function horsey (el, options) {
     if (which === KEY_ENTER) {
       return;
     }
+    if (!visible()) {
+      show();
+    }
     deferredFiltering();
   }
 

--- a/example/example.js
+++ b/example/example.js
@@ -76,12 +76,12 @@ void function () {
   });
 
   horsey(document.querySelector('#locale'), {
-  suggestions: [
-    { value: 'javascript', text: 'js全栈开发者' },
-    { value: 'python', text: '真爱生命，我用python' },
-    { value: 'php', text: '世界上最好的语言，没有之一' },
-    { value: 'java', text: '我的最爱是java' }
-  ]
+    suggestions: [
+      { value: 'javascript', text: 'js全栈开发者' },
+      { value: 'python', text: '珍爱生命，我用python' },
+      { value: 'php', text: 'PHP是世界上最好的语言，没有之一' },
+      { value: 'java', text: '我的最爱是java' }
+    ]
 });
 
   function events (el, type, fn) {

--- a/example/example.js
+++ b/example/example.js
@@ -75,6 +75,15 @@ void function () {
     ]
   });
 
+  horsey(document.querySelector('#locale'), {
+  suggestions: [
+    { value: 'javascript', text: 'js全栈开发者' },
+    { value: 'python', text: '真爱生命，我用python' },
+    { value: 'php', text: '世界上最好的语言，没有之一' },
+    { value: 'java', text: '我的最爱是java' }
+  ]
+});
+
   function events (el, type, fn) {
     if (el.addEventListener) {
       el.addEventListener(type, fn);

--- a/index.html
+++ b/index.html
@@ -139,8 +139,8 @@ horsey(document.querySelector('div'), {
 horsey(document.querySelector('input'), {
   suggestions: [
     { value: 'javascript', text: 'js全栈开发者' },
-    { value: 'python', text: '真爱生命，我用python' },
-    { value: 'php', text: '世界上最好的语言，没有之一' },
+    { value: 'python', text: '珍爱生命，我用python' },
+    { value: 'php', text: 'PHP是世界上最好的语言，没有之一' },
     { value: 'java', text: '我的最爱是java' }
   ]
 });

--- a/index.html
+++ b/index.html
@@ -130,6 +130,23 @@ horsey(document.querySelector('div'), {
       </code>
     </pre>
   </div>
+  <!-- for chinese unicode -->
+  <div class='parent'>
+    <label for='locale'>You can also use in Chinese or other locales: </label>
+    <input id='locale'/>
+    <pre>
+      <code>
+horsey(document.querySelector('input'), {
+  suggestions: [
+    { value: 'javascript', text: 'js全栈开发者' },
+    { value: 'python', text: '真爱生命，我用python' },
+    { value: 'php', text: '世界上最好的语言，没有之一' },
+    { value: 'java', text: '我的最爱是java' }
+  ]
+});
+      </code>
+    </pre>
+  </div>
 </div>
 <h3>Get it on GitHub! <a href='https://github.com/bevacqua/horsey'>bevacqua/horsey</a></h3>
 <script src='dist/horsey.js'></script>


### PR DESCRIPTION
`horse` used `fuzzysearch` to search Text. I want to use it in my website which is Chinese.

But in the [demo websitre](http://bevacqua.github.io/horsey), I add the Chinese testcase, It can not work well. I thought maybe the bug of `fuzzysearch`, so I do a [pull/14](https://github.com/bevacqua/fuzzysearch/pull/14).

In fact, It is a bug of horse. **fixed in this pr**.  and I add the testcase in the demo website. 

![image](https://cloud.githubusercontent.com/assets/7856674/15432215/daef7dcc-1edf-11e6-8ac6-c7d648f32f7c.png)
