### PR TITLE
Fixed inconsistency between code and documentation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ horsey(document.querySelector('input'), {
     { value: 'banana', text: 'Bananas from Amazon Rainforest' },
     { value: 'apple', text: 'Red apples from New Zealand' },
     { value: 'orange', text: 'Oranges from Moscow' },
-    { value: 'lemon', text: 'Juicy lemons from the rich Amalfitan Coast' }
+    { value: 'lemon', text: 'Juicy lemons from Amalfitan Coast' }
   ]}],
   getText: 'text',
   getValue: 'value'


### PR DESCRIPTION
Code: 'Juicy lemons from Amalfitan Coast' vs. Docs:  'Juicy lemons from the rich Amalfitan Coast'